### PR TITLE
Controls which ships carry mission cargo and passengers

### DIFF
--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -326,7 +326,6 @@ outfit "Luxury Accommodations"
 	"mass" 10
 	"outfit space" -10
 	"required crew" 2
-	"preferred transporter" 1
 	"unplunderable" 1
 	description "Most deep space voyages involve a certain amount of passenger discomfort. With the addition of a few extra fresh water tanks, private bathrooms, wooden fixtures, and some hospitality staff, any ship can be made attractive to a significantly higher - and better paying - class of passenger."
 
@@ -398,12 +397,12 @@ outfit "Local Map"
 	"map" 12
 	description "This data chip contains complete information on the twelve star systems closest to this one: planets, ports, governments, trade prices, available services, etc. You can get all the same information just by exploring those systems yourself, but having a map can save you from making wrong turns if you are trying to travel through new territory to reach a certain system quickly."
 
-outfit "Safe Transporter Certificate"
+outfit "Loading Priority Marker"
 	category "Special"
 	cost 500
 	thumbnail "outfit/license"
 	"preferred transporter" 1
-	description "This certificate indicates that a ship can safely carry passengers and cargo. The certification is ignored by nearly everybody, but spaceports are only allowed to board passengers and load customer cargo into certified ships if some ships in the fleet are certified. Those regulations allow fleet captains to reduce the risk of losing passengers or valuable cargo by only certifying their strongest or most-protected transport ships."
+	description "This transponder signals that the ship carrying it is a preferred ship for transporting passengers and cargo. Spaceport crews will board passengers and load customer cargo into preferred ships before boarding and loading other ships. Priority markers allow fleet captains to reduce the risk of losing passengers or valuable cargo by only marking their strongest or most-protected ships as preferred transporters."
 
 outfit "Pilot's License"
 	category "Special"

--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -326,6 +326,7 @@ outfit "Luxury Accommodations"
 	"mass" 10
 	"outfit space" -10
 	"required crew" 2
+	"preferred transporter" 1
 	"unplunderable" 1
 	description "Most deep space voyages involve a certain amount of passenger discomfort. With the addition of a few extra fresh water tanks, private bathrooms, wooden fixtures, and some hospitality staff, any ship can be made attractive to a significantly higher - and better paying - class of passenger."
 
@@ -397,6 +398,12 @@ outfit "Local Map"
 	"map" 12
 	description "This data chip contains complete information on the twelve star systems closest to this one: planets, ports, governments, trade prices, available services, etc. You can get all the same information just by exploring those systems yourself, but having a map can save you from making wrong turns if you are trying to travel through new territory to reach a certain system quickly."
 
+outfit "Safe Transporter Certificate"
+	category "Special"
+	cost 500
+	thumbnail "outfit/license"
+	"preferred transporter" 1
+	description "This certificate indicates that a ship can safely carry passengers and cargo. The certification is ignored by nearly everybody, but spaceports are only allowed to board passengers and load customer cargo into certified ships if some ships in the fleet are certified. Those regulations allow fleet captains to reduce the risk of losing passengers or valuable cargo by only certifying their strongest or most-protected transport ships."
 
 outfit "Pilot's License"
 	category "Special"

--- a/data/outfits.txt
+++ b/data/outfits.txt
@@ -402,7 +402,7 @@ outfit "Loading Priority Marker"
 	cost 500
 	thumbnail "outfit/license"
 	"preferred transporter" 1
-	description "This transponder signals that the ship carrying it is a preferred ship for transporting passengers and cargo. Spaceport crews will board passengers and load customer cargo into preferred ships before boarding and loading other ships. Priority markers allow fleet captains to reduce the risk of losing passengers or valuable cargo by only marking their strongest or most-protected ships as preferred transporters."
+	description "This transponder signals that the ship carrying it is a preferred ship for transporting passengers and cargo. Spaceport crews will board passengers and load customer cargo into preferred ships before any other ships. Priority markers allow fleet captains to reduce the risk of losing passengers or valuable cargo by only marking their strongest or most-protected ships as preferred transport ships."
 
 outfit "Pilot's License"
 	category "Special"

--- a/data/sales.txt
+++ b/data/sales.txt
@@ -169,6 +169,7 @@ outfitter "Common Outfits"
 	"Supercapacitor"
 	"Local Map"
 	"Pilot's License"
+	"Safe Transporter Certificate"
 	"Laser Rifle"
 
 outfitter "Basic Weapons"

--- a/data/sales.txt
+++ b/data/sales.txt
@@ -169,7 +169,7 @@ outfitter "Common Outfits"
 	"Supercapacitor"
 	"Local Map"
 	"Pilot's License"
-	"Safe Transporter Certificate"
+	"Loading Priority Marker"
 	"Laser Rifle"
 
 outfitter "Basic Weapons"

--- a/source/CargoHold.h
+++ b/source/CargoHold.h
@@ -46,16 +46,23 @@ public:
 	int Size() const;
 	int Free() const;
 	int Used() const;
+	void SetSafeSize(int tons);
+	int SafeSize() const;
+	int SafeFree() const;
 	int CommoditiesSize() const;
+	int CommoditiesOversize() const;
 	int OutfitsSize() const;
 	bool HasOutfits() const;
 	int MissionCargoSize() const;
 	bool HasMissionCargo() const;
 	bool IsEmpty() const;
+	bool IsEmptyExceptCommododities() const;
 	
 	// Set the number of free bunks for passengers.
 	void SetBunks(int count);
+	void SetPassengerBunks(int count);
 	int BunksFree() const;
+	int PassengerBunksFree() const;
 	int Passengers() const;
 	
 	// Normal cargo:
@@ -108,6 +115,8 @@ private:
 	// Use -1 to indicate unlimited capacity.
 	int size = -1;
 	int bunks = -1;
+	int passengerBunks = -1;
+	int safeSize = -1;
 	
 	// Track how many objects of each type are being carried:
 	std::map<std::string, int> commodities;

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -608,8 +608,8 @@ bool Mission::HasSpace(const PlayerInfo &player) const
 	int extraCrew = 0;
 	if(player.Flagship())
 		extraCrew = player.Flagship()->Crew() - player.Flagship()->RequiredCrew();
-	return (cargoSize <= player.Cargo().Free() + player.Cargo().CommoditiesSize()
-		&& passengers <= player.Cargo().BunksFree() + extraCrew);
+	return (cargoSize <= player.Cargo().SafeFree() + player.Cargo().CommoditiesOversize()
+		&& passengers <= player.Cargo().PassengerBunksFree() + extraCrew);
 }
 
 
@@ -617,7 +617,7 @@ bool Mission::HasSpace(const PlayerInfo &player) const
 // Check if this mission's cargo can fit entirely on the referenced ship.
 bool Mission::HasSpace(const Ship &ship) const
 {
-	return (cargoSize <= ship.Cargo().Free() && passengers <= ship.Cargo().BunksFree());
+	return (cargoSize <= ship.Cargo().SafeFree() && passengers <= ship.Cargo().PassengerBunksFree());
 }
 
 
@@ -705,8 +705,8 @@ string Mission::BlockedMessage(const PlayerInfo &player)
 	int bunksNeeded = passengers;
 	if(player.GetPlanet())
 	{
-		cargoNeeded -= (player.Cargo().Free() + player.Cargo().CommoditiesSize());
-		bunksNeeded -= (player.Cargo().BunksFree() + extraCrew);
+		cargoNeeded -= (player.Cargo().SafeFree() + player.Cargo().CommoditiesOversize());
+		bunksNeeded -= (player.Cargo().PassengerBunksFree() + extraCrew);
 	}
 	else
 	{

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -629,8 +629,8 @@ void MissionPanel::DrawMissionInfo()
 	else if(acceptedIt != accepted.end())
 		info.SetCondition("can abort");
 	
-	info.SetString("cargo free", to_string(player.Cargo().Free()) + " tons");
-	info.SetString("bunks free", to_string(player.Cargo().BunksFree()) + " bunks");
+	info.SetString("cargo free", to_string(player.Cargo().SafeFree()) + " tons");
+	info.SetString("bunks free", to_string(player.Cargo().PassengerBunksFree()) + " bunks");
 	
 	info.SetString("today", player.GetDate().ToString());
 	
@@ -667,7 +667,7 @@ void MissionPanel::Accept()
 		cargoToSell = toAccept.CargoSize() - player.Cargo().Free();
 	int crewToFire = 0;
 	if(toAccept.Passengers())
-		crewToFire = toAccept.Passengers() - player.Cargo().BunksFree();
+		crewToFire = toAccept.Passengers() - player.Cargo().PassengerBunksFree();
 	if(cargoToSell > 0 || crewToFire > 0)
 	{
 		ostringstream out;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -516,7 +516,12 @@ void Ship::FinishLoading(bool isNewInstance)
 			Files::LogError(warning);
 		}
 	}
-	cargo.SetSize(attributes.Get("cargo space"));
+	int cargoSpace = attributes.Get("cargo space");
+	int safeCargoSpace = cargoSpace;
+	if (! attributes.Get("preferred transporter"))
+		safeCargoSpace = 0;
+	cargo.SetSize(cargoSpace);
+	cargo.SetSafeSize(safeCargoSpace);
 	equipped.clear();
 	armament.FinishLoading();
 	
@@ -2917,8 +2922,15 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		if(outfit->IsWeapon())
 			armament.Add(outfit, count);
 		
-		if(outfit->Get("cargo space"))
-			cargo.SetSize(attributes.Get("cargo space"));
+		if(outfit->Get("cargo space") || outfit->Get("preferred transporter"))
+		{
+			int cargoSpace = attributes.Get("cargo space");
+			int safeCargoSpace = cargoSpace;
+			if (!attributes.Get("preferred transporter"))
+				safeCargoSpace = 0;
+			cargo.SetSize(cargoSpace);
+			cargo.SetSafeSize(safeCargoSpace);
+		}
 		if(outfit->Get("hull"))
 			hull += outfit->Get("hull") * count;
 	}


### PR DESCRIPTION
Something that bothered me a lot while playing Endless Sky was that my strong transport ships were empty while some of my weak front-line fighter ships ended up carrying mission critical cargo. Losing a front-line fighter then meant losing mission(s).

This commit adds a certificate that controls which ships carry mission cargo, passengers and outfits. Fleet captains can use this certificate to avoid carrying critical cargo on front-line battleships.

The loading mechanism introduced in this commit does not conflict with the plans that I read about to differentiate between regular bunks, luxury accommodations and jail cells.