### PR TITLE
Modify Cargo Button Label

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -102,7 +102,7 @@ int OutfitterPanel::VisiblityCheckboxesSize() const
 
 string OutfitterPanel::ShipsDeselectText() const
 {
-	return "Cargo";
+	return "Cargo & Storage";
 }
 
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -274,12 +274,12 @@ void ShopPanel::DrawShipsSidebar()
 
 		point.Y() += ICON_TILE;
 		const Point cargoModeButtonCenter = Point(Screen::Right() - SIDEBAR_WIDTH / 2, point.Y());
-		FillShader::Fill(cargoModeButtonCenter, Point(60, 30), playerShip ? back : activeBack);
+		FillShader::Fill(cargoModeButtonCenter, Point(140, 30), playerShip ? back : activeBack);
 		bigFont.Draw(deSelectText,
 			cargoModeButtonCenter - .5 * Point(bigFont.Width(deSelectText), bigFont.Height()),
 			playerShip ? inactive : active);
 
-		zones.emplace_back(cargoModeButtonCenter, Point(60, 30), 'a');
+		zones.emplace_back(cargoModeButtonCenter, Point(140, 30), 'a');
 	}
 	point.Y() += ICON_TILE;
 


### PR DESCRIPTION
Feature: This PR makes a change to the cargo button text as I suggested https://github.com/endless-sky/endless-sky/pull/6705

## Feature Details
Instead of "Cargo" the button now reads "Cargo & Storage" and the background size has been updated as necessary. I think this wording is more obvious but the button itself is a great idea regardless.

## UI Screenshots
![Cargo   Storage](https://user-images.githubusercontent.com/80174383/162653395-0b826bd8-0209-48af-ba91-7459d4ee827e.png)

## Usage Examples
N/A

## Testing Done
It looks right and no functionality was changed.

## Performance Impact
None
